### PR TITLE
Fix build pipeline and Play.bat runtime issues

### DIFF
--- a/Play.bat
+++ b/Play.bat
@@ -1,20 +1,19 @@
 @echo off
 setlocal
 
-REM Change to the directory of the batch file
 cd /d "%~dp0"
 
-REM Copy the executable to the batch file's directory
-echo Copying retip.exe to the batch file's directory...
+echo Copying retip.exe and DLLs to the batch file's directory...
 copy /y "out\build\win-amd64-relwithdebinfo\retip.exe" .
+copy /y "out\build\win-amd64-relwithdebinfo\*.dll" .
 
-REM Check if the copy was successful
 if not exist retip.exe (
     echo ERROR: Failed to copy retip.exe to %cd%
     pause
     exit /b 1
 )
 
-REM Start the executable with launch arguments
 echo Starting retip.exe with arguments...
-retip.exe --gpu_allow_invalid_fetch_constants=true --enable_console=false --scribble_heap=true --vsync=off --fullscreen=true --video_mode_refresh_rate=164
+retip.exe --gpu_allow_invalid_fetch_constants=true --enable_console=true --scribble_heap=true --vsync=off --fullscreen=false --video_mode_refresh_rate=164
+
+pause

--- a/RegenAndRebuild.bat
+++ b/RegenAndRebuild.bat
@@ -1,5 +1,75 @@
+@echo off
+setlocal
+
+REM Go to script directory
+cd /d "%~dp0"
+
+echo ================================
+echo Step 1 Running rexglue migrate
+echo ================================
+rexglue migrate --app_root .
+if errorlevel 1 (
+    echo ERROR: migrate failed
+    pause
+    exit /b 1
+)
+
+echo ================================
+echo Step 2 Configure
+echo ================================
 cmake --preset win-amd64-relwithdebinfo
+if errorlevel 1 (
+    echo ERROR: configure failed
+    pause
+    exit /b 1
+)
+
+echo ================================
+echo Step 3 Run codegen
+echo ================================
 cmake --build --preset win-amd64-relwithdebinfo --target retip_codegen
+if errorlevel 1 (
+    echo ERROR: codegen failed
+    pause
+    exit /b 1
+)
+
+echo ================================
+echo Step 4 Restore original files
+echo ================================
+if exist CMakeLists.txt.bak (
+    copy /y CMakeLists.txt.bak CMakeLists.txt >nul
+) else (
+    echo WARNING: CMakeLists.txt.bak not found
+)
+
+if exist src\main.cpp.bak (
+    copy /y src\main.cpp.bak src\main.cpp >nul
+) else (
+    echo WARNING: src\main.cpp.bak not found
+)
+
+echo ================================
+echo Step 5 Reconfigure
+echo ================================
 cmake --preset win-amd64-relwithdebinfo
+if errorlevel 1 (
+    echo ERROR: reconfigure failed
+    pause
+    exit /b 1
+)
+
+echo ================================
+echo Step 6 Final build
+echo ================================
 cmake --build --preset win-amd64-relwithdebinfo
+if errorlevel 1 (
+    echo ERROR: build failed
+    pause
+    exit /b 1
+)
+
+echo ================================
+echo Build completed successfully
+echo ================================
 pause


### PR DESCRIPTION
Fixes issues with building and running from fresh clone.

RegenAndRebuild.bat Changes:
- Adds rexglue migrate step 
- Runs codegen before restoration of CMakeLists.txt and src/main.cpp from backup
- Restores CMakeLists.txt and src/main.cpp
- Final build with restored files

Play.bat Changes:
- Updated Play.bat to copy required .dll file to prevent error