### PR TITLE
Improved Romance Minigame and focus input handling with KBM.

### DIFF
--- a/src/tip_engine/Globals.h
+++ b/src/tip_engine/Globals.h
@@ -46,6 +46,7 @@ inline rex::input::InputSystem* g_input_system = nullptr;
 // Set while host UI owns input, such as TiPTools or Alt-unlocked cursor mode.
 inline bool g_LockGameInput = false;
 inline bool g_RetipInputUiMode = false;
+inline bool g_InRomanceMinigame = false;
 
 inline bool IsRetipGameInputActive() {
     if (g_LockGameInput) {
@@ -73,6 +74,27 @@ inline void SetRetipInputUiMode(bool ui_mode) {
     g_input_system->SetInputMode(ui_mode ? rex::input::InputMode::kUIOnly
                                          : rex::input::InputMode::kGame);
     g_input_system->SetShowMouseCursor(ui_mode);
+}
+
+inline void FlushRetipMouseInput() {
+    if (g_raw_mouse) {
+        g_raw_mouse->ConsumeDelta();
+        g_raw_mouse->ConsumeWheel();
+    }
+
+    if (g_mouse_listener) {
+        g_mouse_listener->ConsumeDelta();
+        g_mouse_listener->ConsumeWheel();
+    }
+}
+
+inline void SetRetipRomanceMinigame(bool active) {
+    if (g_InRomanceMinigame == active) {
+        return;
+    }
+
+    g_InRomanceMinigame = active;
+    FlushRetipMouseInput();
 }
 
 inline uint32_t scene = 0;

--- a/src/tip_engine/Overlays/TiPTools.cpp
+++ b/src/tip_engine/Overlays/TiPTools.cpp
@@ -22,12 +22,12 @@ static constexpr float kHeaderHeight = 38.0f;
 static constexpr float kWarningHeight = 18.0f;
 
 static bool IsAltUnlockHeld(const ImGuiIO& io) {
-    if (io.KeyAlt || ImGui::IsKeyDown(ImGuiKey_LeftAlt) || ImGui::IsKeyDown(ImGuiKey_RightAlt)) {
-        return true;
-    }
 #ifdef _WIN32
     return (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
 #else
+    if (io.KeyAlt || ImGui::IsKeyDown(ImGuiKey_LeftAlt) || ImGui::IsKeyDown(ImGuiKey_RightAlt)) {
+        return true;
+    }
     return false;
 #endif
 }

--- a/src/tip_engine/hooks.cpp
+++ b/src/tip_engine/hooks.cpp
@@ -233,15 +233,16 @@ void vsync_hook(PPCRegister& r10) {
 
 inline bool VSyncBefore;
 inline bool lockFPSBefore;
-inline bool InRomanceMinigame = false;
+inline bool SavedRomanceVideoState = false;
 
 void InRomanceMinigame_hook(){
   Log(LogLevel::Info, "In Romance Minigame Hook Hit");
-  if(!InRomanceMinigame) {
+  if(!g_InRomanceMinigame) {
     VSyncBefore = REXCVAR_GET(vsync);
     lockFPSBefore = REXCVAR_GET(lock_fps);
+    SavedRomanceVideoState = true;
   }
-  InRomanceMinigame = true;
+  SetRetipRomanceMinigame(true);
   REXCVAR_SET(vsync, true);
   REXCVAR_SET(lock_fps, true);
   Log(LogLevel::Info, "In Romance Minigame Hook Finished");
@@ -249,9 +250,12 @@ void InRomanceMinigame_hook(){
 
 void NotInRomanceMinigame_hook(){
   Log(LogLevel::Info, "Not In Romance Minigame Hook Hit");
-  REXCVAR_SET(vsync, VSyncBefore);
-  REXCVAR_SET(lock_fps, lockFPSBefore);
-  InRomanceMinigame = false;
+  if(g_InRomanceMinigame && SavedRomanceVideoState) {
+    REXCVAR_SET(vsync, VSyncBefore);
+    REXCVAR_SET(lock_fps, lockFPSBefore);
+  }
+  SavedRomanceVideoState = false;
+  SetRetipRomanceMinigame(false);
   Log(LogLevel::Info, "Not In Romance Minigame Hook Finished");
 }
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  - Improves KBM behavior around romance minigames by tracking romance state explicitly.                                                                                                                                         
  - Flushes pending mouse delta/wheel input when entering or leaving romance minigames.                                                                                                                                          
  - Makes Windows Alt cursor unlock use live Win32 key state instead of stale ImGui Alt state. 
  - Fixed some bugs related to KBM not working anymore if you Alt-Tabbed the game.                                                                                                                                  
                                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  | File | Change |                                                                                                                                                                                                              
  |------|--------|                                                                                                                                                                                                              
  | `src/tip_engine/Globals.h` | Added shared romance-minigame state and mouse input flushing helpers. |                                                                                                                         
  | `src/tip_engine/hooks.cpp` | Updated romance hooks to save/restore video cvars safely and clear romance state on exit. |                                                                                                     
  | `src/tip_engine/Overlays/TiPTools.cpp` | Changed Windows Alt unlock detection to use `GetAsyncKeyState(VK_MENU)`. |                                                                                                          
                                                                                                                                                                                                                                 
  ## Testing                                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  - [x] Romance minigame KBM movement tested.                                                                                                                                                                                    
  - [x] Mouse zoom tested after the romance/focus changes.                                                                                                                                                                       
  - [x] Alt unlock tested on Windows.                                                                                                                                                                                            
  - [x] Alt-Tab recovery tested together with the Rexglue-side focus fix.                                                                                                                                                        
                                                                                                                                                                                                                                 
  ## Notes                                                                                                                                                                                                                       
                                                                                                                                                                                                                                 
  This PR pairs with the Rexglue KBM/focus commit at [https://github.com/SolarCookies/rexglue-sdk/tree/VivaPinata](https://github.com/SolarCookies/rexglue-sdk/tree/VivaPinata). The TiP-Recomp side handles game-specific state and input flushing; Rexglue handles platform focus/capture recovery.