### PR TITLE
Stop Discord RPC during app shutdown

### DIFF
--- a/src/retip_app.h
+++ b/src/retip_app.h
@@ -114,6 +114,7 @@ class RetipApp : public rex::ReXApp {
   }
 
   void OnShutdown() override {
+    rex::discord_rpc::Stop();
     if (launch_dialog_) launch_dialog_->ReleaseWallpaper();
   }
 


### PR DESCRIPTION
TiP starts Discord RPC during setup but did not stop it in `OnShutdown()`. That left the worker running until process teardown.

This adds an explicit `Stop()` call before the existing wallpaper cleanup. It goes with https://github.com/SolarRecomps/rexglue-ostentation/pull/2, which cleans up the runtime-side shutdown path.

I rebuilt the generated code from the current `dev` branch and completed a full RelWithDebInfo build. That branch does not currently register any CTest tests.